### PR TITLE
Add assertion aliases for redux-saga effect creators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -437,6 +437,16 @@
       "integrity": "sha512-akKkzcVnb1RzJaZV2LQFbi51abvdICMuAKwwLoCjjxLbLAGIw9EJxk5ucNnWSSCEsoEQMeol5tkAcK+Xzuv1Bg==",
       "dev": true
     },
+    "@redux-saga/testing-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/testing-utils/-/testing-utils-1.1.1.tgz",
+      "integrity": "sha512-Mg7cXXCRWMkJ5nsp0gPSFHVdsPJeTbizWnlNBc9oG+775eC7PTU9YVdpfZsWkikGwTS0s9jEGi3B+X6FIzYtEA==",
+      "dev": true,
+      "requires": {
+        "@redux-saga/symbols": "^1.1.0",
+        "@redux-saga/types": "^1.1.0"
+      }
+    },
     "@redux-saga/types": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@redux-saga/testing-utils": "^1.1.1",
     "@types/jest": "^24.0.11",
     "@types/node": "^11.13.4",
     "coveralls": "^3.0.3",

--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -1,0 +1,522 @@
+import { Action } from 'redux'
+import {
+  TakeableChannel,
+  PuttableChannel,
+  FlushableChannel,
+  END,
+} from 'redux-saga'
+import {
+  ChannelPutEffect,
+  HelperWorkerParameters,
+  ActionPattern,
+  Pattern,
+  Tail,
+  take,
+  takeMaybe,
+  takeEvery,
+  takeLatest,
+  takeLeading,
+  put,
+  putResolve,
+  call,
+  apply,
+  cps,
+  CpsCallback,
+  CpsFunctionParameters,
+  fork,
+  spawn,
+  join,
+  cancel,
+  select,
+  actionChannel,
+  flush,
+  cancelled,
+  setContext,
+  getContext,
+  delay,
+  throttle,
+  debounce,
+  retry,
+  all,
+  race,
+} from 'redux-saga/effects'
+import { ActionMatchingPattern, Effect, Task, Buffer } from '@redux-saga/types'
+
+export interface ExtendedSagaAssertions<R> {
+  /**
+   * Alias for `should.yield(take(...))`
+   */
+  take(pattern?: ActionPattern): R
+
+  take<A extends Action>(pattern?: ActionPattern<A>): R
+
+  take<T>(channel: TakeableChannel<T>, multicastPattern?: Pattern<T>): R
+
+  /**
+   * Alias for `should.yield(takeMaybe(...))`
+   */
+  takeMaybe(pattern?: ActionPattern): R
+
+  takeMaybe<A extends Action>(pattern?: ActionPattern<A>): R
+
+  takeMaybe<T>(channel: TakeableChannel<T>, multicastPattern?: Pattern<T>): R
+
+  /**
+   * Alias for `should.yield(takeEvery(...))`
+   */
+  takeEvery<P extends ActionPattern>(
+    pattern: P,
+    worker: (action: ActionMatchingPattern<P>) => any,
+  ): R
+
+  takeEvery<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+    pattern: P,
+    worker: Fn,
+    ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+  ): R
+
+  takeEvery<A extends Action>(
+    pattern: ActionPattern<A>,
+    worker: (action: A) => any,
+  ): R
+
+  takeEvery<A extends Action, Fn extends (...args: any[]) => any>(
+    pattern: ActionPattern<A>,
+    worker: Fn,
+    ...args: HelperWorkerParameters<A, Fn>
+  ): R
+
+  takeEvery<T>(channel: TakeableChannel<T>, worker: (item: T) => any): R
+
+  takeEvery<T, Fn extends (...args: any[]) => any>(
+    channel: TakeableChannel<T>,
+    worker: Fn,
+    ...args: HelperWorkerParameters<T, Fn>
+  ): R
+
+  /**
+   * Alias for `should.yield(takeLatest(...))`
+   */
+  takeLatest<P extends ActionPattern>(
+    pattern: P,
+    worker: (action: ActionMatchingPattern<P>) => any,
+  ): R
+
+  takeLatest<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+    pattern: P,
+    worker: Fn,
+    ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+  ): R
+
+  takeLatest<A extends Action>(
+    pattern: ActionPattern<A>,
+    worker: (action: A) => any,
+  ): R
+
+  takeLatest<A extends Action, Fn extends (...args: any[]) => any>(
+    pattern: ActionPattern<A>,
+    worker: Fn,
+    ...args: HelperWorkerParameters<A, Fn>
+  ): R
+
+  takeLatest<T>(channel: TakeableChannel<T>, worker: (item: T) => any): R
+
+  takeLatest<T, Fn extends (...args: any[]) => any>(
+    channel: TakeableChannel<T>,
+    worker: Fn,
+    ...args: HelperWorkerParameters<T, Fn>
+  ): R
+
+  /**
+   * Alias for `should.yield(takeLeading(...))`
+   */
+  takeLeading<P extends ActionPattern>(
+    pattern: P,
+    worker: (action: ActionMatchingPattern<P>) => any,
+  ): R
+
+  takeLeading<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+    pattern: P,
+    worker: Fn,
+    ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+  ): R
+
+  takeLeading<A extends Action>(
+    pattern: ActionPattern<A>,
+    worker: (action: A) => any,
+  ): R
+
+  takeLeading<A extends Action, Fn extends (...args: any[]) => any>(
+    pattern: ActionPattern<A>,
+    worker: Fn,
+    ...args: HelperWorkerParameters<A, Fn>
+  ): R
+
+  takeLeading<T>(channel: TakeableChannel<T>, worker: (item: T) => any): R
+
+  takeLeading<T, Fn extends (...args: any[]) => any>(
+    channel: TakeableChannel<T>,
+    worker: Fn,
+    ...args: HelperWorkerParameters<T, Fn>
+  ): R
+
+  /**
+   * Alias for `should.yield(put(...))`
+   */
+  put<A extends Action>(action: A): R
+
+  put<T>(channel: PuttableChannel<T>, action: T | END): ChannelPutEffect<T>
+
+  /**
+   * Alias for `should.yield(putResolve(...))`
+   */
+  putResolve<A extends Action>(action: A): R
+
+  /**
+   * Alias for `should.yield(call(...))`
+   */
+  call<Fn extends (...args: any[]) => any>(fn: Fn, ...args: Parameters<Fn>): R
+
+  call<
+    Ctx extends { [P in Name]: (this: Ctx, ...args: any[]) => any },
+    Name extends string
+  >(
+    ctxAndFnName: [Ctx, Name],
+    ...args: Parameters<Ctx[Name]>
+  ): R
+
+  call<
+    Ctx extends { [P in Name]: (this: Ctx, ...args: any[]) => any },
+    Name extends string
+  >(
+    ctxAndFnName: { context: Ctx; fn: Name },
+    ...args: Parameters<Ctx[Name]>
+  ): R
+
+  call<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+    ctxAndFn: [Ctx, Fn],
+    ...args: Parameters<Fn>
+  ): R
+
+  call<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+    ctxAndFn: { context: Ctx; fn: Fn },
+    ...args: Parameters<Fn>
+  ): R
+
+  /**
+   * Alias for `should.yield(apply(...))`
+   */
+  apply<
+    Ctx extends { [P in Name]: (this: Ctx, ...args: any[]) => any },
+    Name extends string
+  >(
+    ctx: Ctx,
+    fnName: Name,
+    args: Parameters<Ctx[Name]>,
+  ): R
+
+  apply<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+    ctx: Ctx,
+    fn: Fn,
+    args: Parameters<Fn>,
+  ): R
+
+  /**
+   * Alias for `should.yield(cps(...))`
+   */
+  cps<Fn extends (cb: CpsCallback<any>) => any>(fn: Fn): R
+
+  cps<Fn extends (...args: any[]) => any>(
+    fn: Fn,
+    ...args: CpsFunctionParameters<Fn>
+  ): R
+
+  cps<
+    Ctx extends { [P in Name]: (this: Ctx, ...args: any[]) => void },
+    Name extends string
+  >(
+    ctxAndFnName: [Ctx, Name],
+    ...args: CpsFunctionParameters<Ctx[Name]>
+  ): R
+
+  cps<
+    Ctx extends { [P in Name]: (this: Ctx, ...args: any[]) => void },
+    Name extends string
+  >(
+    ctxAndFnName: { context: Ctx; fn: Name },
+    ...args: CpsFunctionParameters<Ctx[Name]>
+  ): R
+
+  cps<Ctx, Fn extends (this: Ctx, ...args: any[]) => void>(
+    ctxAndFn: [Ctx, Fn],
+    ...args: CpsFunctionParameters<Fn>
+  ): R
+
+  cps<Ctx, Fn extends (this: Ctx, ...args: any[]) => void>(
+    ctxAndFn: { context: Ctx; fn: Fn },
+    ...args: CpsFunctionParameters<Fn>
+  ): R
+
+  /**
+   * Alias for `should.yield(fork(...))`
+   */
+  fork<Fn extends (...args: any[]) => any>(fn: Fn, ...args: Parameters<Fn>): R
+
+  fork<
+    Ctx extends { [P in Name]: (this: Ctx, ...args: any[]) => any },
+    Name extends string
+  >(
+    ctxAndFnName: [Ctx, Name],
+    ...args: Parameters<Ctx[Name]>
+  ): R
+
+  fork<
+    Ctx extends { [P in Name]: (this: Ctx, ...args: any[]) => any },
+    Name extends string
+  >(
+    ctxAndFnName: { context: Ctx; fn: Name },
+    ...args: Parameters<Ctx[Name]>
+  ): R
+
+  fork<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+    ctxAndFn: [Ctx, Fn],
+    ...args: Parameters<Fn>
+  ): R
+
+  fork<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+    ctxAndFn: { context: Ctx; fn: Fn },
+    ...args: Parameters<Fn>
+  ): R
+
+  /**
+   * Alias for `should.yield(spawn(...))`
+   */
+  spawn<Fn extends (...args: any[]) => any>(fn: Fn, ...args: Parameters<Fn>): R
+
+  spawn<
+    Ctx extends { [P in Name]: (this: Ctx, ...args: any[]) => any },
+    Name extends string
+  >(
+    ctxAndFnName: [Ctx, Name],
+    ...args: Parameters<Ctx[Name]>
+  ): R
+
+  spawn<
+    Ctx extends { [P in Name]: (this: Ctx, ...args: any[]) => any },
+    Name extends string
+  >(
+    ctxAndFnName: { context: Ctx; fn: Name },
+    ...args: Parameters<Ctx[Name]>
+  ): R
+
+  spawn<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+    ctxAndFn: [Ctx, Fn],
+    ...args: Parameters<Fn>
+  ): R
+
+  spawn<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+    ctxAndFn: { context: Ctx; fn: Fn },
+    ...args: Parameters<Fn>
+  ): R
+
+  /**
+   * Alias for `should.yield(join(...))`
+   */
+  join(task: Task): R
+
+  join(tasks: Task[]): R
+
+  /**
+   * Alias for `should.yield(cancel(...))`
+   */
+  cancel(task: Task): R
+
+  cancel(tasks: Task[]): R
+
+  cancel(): R
+
+  /**
+   * Alias for `should.yield(select(...))`
+   */
+  select(): R
+
+  select<Fn extends (state: any, ...args: any[]) => any>(
+    selector: Fn,
+    ...args: Tail<Parameters<Fn>>
+  ): R
+
+  /**
+   * Alias for `should.yield(actionChannel(...))`
+   */
+  actionChannel(pattern: ActionPattern, buffer?: Buffer<Action>): R
+
+  /**
+   * Alias for `should.yield(flush(...))`
+   */
+  flush<T>(channel: FlushableChannel<T>): R
+
+  /**
+   * Alias for `should.yield(cancelled(...))`
+   */
+  cancelled(): R
+
+  /**
+   * Alias for `should.yield(setContext(...))`
+   */
+  setContext<C extends object>(props: C): R
+
+  /**
+   * Alias for `should.yield(getContext(...))`
+   */
+  getContext(prop: string): R
+
+  /**
+   * Alias for `should.yield(delay(...))`
+   */
+  delay<T = true>(ms: number, val?: T): R
+
+  /**
+   * Alias for `should.yield(throttle(...))`
+   */
+  throttle<P extends ActionPattern>(
+    ms: number,
+    pattern: P,
+    worker: (action: ActionMatchingPattern<P>) => any,
+  ): R
+
+  throttle<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+    ms: number,
+    pattern: P,
+    worker: Fn,
+    ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+  ): R
+
+  throttle<A extends Action>(
+    ms: number,
+    pattern: ActionPattern<A>,
+    worker: (action: A) => any,
+  ): R
+
+  throttle<A extends Action, Fn extends (...args: any[]) => any>(
+    ms: number,
+    pattern: ActionPattern<A>,
+    worker: Fn,
+    ...args: HelperWorkerParameters<A, Fn>
+  ): R
+
+  throttle<T>(
+    ms: number,
+    channel: TakeableChannel<T>,
+    worker: (item: T) => any,
+  ): R
+
+  throttle<T, Fn extends (...args: any[]) => any>(
+    ms: number,
+    channel: TakeableChannel<T>,
+    worker: Fn,
+    ...args: HelperWorkerParameters<T, Fn>
+  ): R
+
+  /**
+   * Alias for `should.yield(debounce(...))`
+   */
+  debounce<P extends ActionPattern>(
+    ms: number,
+    pattern: P,
+    worker: (action: ActionMatchingPattern<P>) => any,
+  ): R
+
+  debounce<P extends ActionPattern, Fn extends (...args: any[]) => any>(
+    ms: number,
+    pattern: P,
+    worker: Fn,
+    ...args: HelperWorkerParameters<ActionMatchingPattern<P>, Fn>
+  ): R
+
+  debounce<A extends Action>(
+    ms: number,
+    pattern: ActionPattern<A>,
+    worker: (action: A) => any,
+  ): R
+
+  debounce<A extends Action, Fn extends (...args: any[]) => any>(
+    ms: number,
+    pattern: ActionPattern<A>,
+    worker: Fn,
+    ...args: HelperWorkerParameters<A, Fn>
+  ): R
+
+  debounce<T>(
+    ms: number,
+    channel: TakeableChannel<T>,
+    worker: (item: T) => any,
+  ): R
+
+  debounce<T, Fn extends (...args: any[]) => any>(
+    ms: number,
+    channel: TakeableChannel<T>,
+    worker: Fn,
+    ...args: HelperWorkerParameters<T, Fn>
+  ): R
+
+  /**
+   * Alias for `should.yield(retry(...))`
+   */
+  retry<Fn extends (...args: any[]) => any>(
+    maxTries: number,
+    delayLength: number,
+    fn: Fn,
+    ...args: Parameters<Fn>
+  ): R
+
+  /**
+   * Alias for `should.yield(all(...))`
+   */
+  all<T>(effects: T[]): R
+
+  all<T>(effects: { [key: string]: T }): R
+
+  /**
+   * Alias for `should.yield(race(...))`
+   */
+  race<T>(effects: { [key: string]: T }): R
+
+  race<T>(effects: T[]): R
+}
+
+export const withExtendedSagaAssertions = <R>(runner: {
+  should: { yield: (effect: Effect) => R }
+}) => {
+  const createAlias = (effectCreator: (...args: any[]) => Effect) => (
+    ...args: any[]
+  ) => runner.should.yield(effectCreator(...args))
+
+  return {
+    put: createAlias(put),
+    take: createAlias(take),
+    takeMaybe: createAlias(takeMaybe),
+    takeEvery: createAlias(takeEvery),
+    takeLatest: createAlias(takeLatest),
+    takeLeading: createAlias(takeLeading),
+    putResolve: createAlias(putResolve),
+    call: createAlias(call),
+    apply: createAlias(apply),
+    cps: createAlias(cps),
+    fork: createAlias(fork),
+    spawn: createAlias(spawn),
+    join: createAlias(join),
+    cancel: createAlias(cancel),
+    select: createAlias(select),
+    actionChannel: createAlias(actionChannel),
+    flush: createAlias(flush),
+    cancelled: createAlias(cancelled),
+    setContext: createAlias(setContext),
+    getContext: createAlias(getContext),
+    delay: createAlias(delay),
+    throttle: createAlias(throttle),
+    debounce: createAlias(debounce),
+    retry: createAlias(retry),
+    all: createAlias(all),
+    race: createAlias(race),
+  }
+}

--- a/test/aliases.test.ts
+++ b/test/aliases.test.ts
@@ -1,0 +1,314 @@
+import {
+  take,
+  takeMaybe,
+  takeEvery,
+  takeLatest,
+  takeLeading,
+  put,
+  putResolve,
+  call,
+  apply,
+  cps,
+  fork,
+  spawn,
+  join,
+  cancel,
+  select,
+  actionChannel,
+  flush,
+  cancelled,
+  setContext,
+  getContext,
+  delay,
+  throttle,
+  debounce,
+  retry,
+  all,
+  race,
+} from 'redux-saga/effects'
+import { createMockTask } from '@redux-saga/testing-utils'
+import { use } from '../src/runner'
+import { Task, channel } from 'redux-saga'
+
+const fn1 = () => {}
+const fn2 = () => {}
+
+test('should.take()', () => {
+  const saga = function*() {
+    yield take('FETCH')
+  }
+
+  use(saga)
+    .should.take('FETCH')
+    .run()
+})
+
+test('should.takeMaybe()', () => {
+  const saga = function*() {
+    yield takeMaybe('FETCH')
+  }
+
+  use(saga)
+    .should.takeMaybe('FETCH')
+    .run()
+})
+
+test('should.takeEvery()', () => {
+  const saga = function*() {
+    yield takeEvery('FETCH', fn1)
+  }
+
+  use(saga)
+    .should.takeEvery('FETCH', fn1)
+    .run()
+})
+
+test('should.takeLatest()', () => {
+  const saga = function*() {
+    yield takeLatest('FETCH', fn1)
+  }
+
+  use(saga)
+    .should.takeLatest('FETCH', fn1)
+    .run()
+})
+
+test('should.takeLeading()', () => {
+  const saga = function*() {
+    yield takeLeading('FETCH', fn1)
+  }
+
+  use(saga)
+    .should.takeLeading('FETCH', fn1)
+    .run()
+})
+
+test('should.put()', () => {
+  const saga = function*() {
+    yield put({ type: 'SUCCESS' })
+  }
+
+  use(saga)
+    .should.put({ type: 'SUCCESS' })
+    .run()
+})
+
+test('should.putResolve()', () => {
+  const saga = function*() {
+    yield putResolve({ type: 'SUCCESS' })
+  }
+
+  use(saga)
+    .should.putResolve({ type: 'SUCCESS' })
+    .run()
+})
+
+test('should.call()', () => {
+  const saga = function*() {
+    yield call(fn1)
+  }
+
+  use(saga)
+    .should.call(fn1)
+    .run()
+})
+
+test('should.apply()', () => {
+  const saga = function*() {
+    yield apply({ key: 'value' }, fn1, [])
+  }
+
+  use(saga)
+    .should.apply({ key: 'value' }, fn1, [])
+    .run()
+})
+
+test('should.cps()', () => {
+  const saga = function*() {
+    yield cps(fn1)
+  }
+
+  use(saga)
+    .should.cps(fn1)
+    .run()
+})
+
+test('should.fork()', () => {
+  const saga = function*() {
+    yield fork(fn1)
+  }
+
+  use(saga)
+    .should.fork(fn1)
+    .run()
+})
+
+test('should.spawn()', () => {
+  const saga = function*() {
+    yield spawn(fn1)
+  }
+
+  use(saga)
+    .should.spawn(fn1)
+    .run()
+})
+
+test('should.join()', () => {
+  const mockTask = createMockTask()
+
+  const saga = function*() {
+    const task: Task = yield fork(fn1)
+    yield join(task)
+  }
+
+  use(saga)
+    .mock(fork(fn1), mockTask)
+    .should.join(mockTask)
+    .run()
+})
+
+test('should.cancel()', () => {
+  const mockTask = createMockTask()
+
+  const saga = function*() {
+    const task: Task = yield fork(fn1)
+    yield cancel(task)
+  }
+
+  use(saga)
+    .mock(fork(fn1), mockTask)
+    .should.cancel(mockTask)
+    .run()
+})
+
+test('should.select()', () => {
+  const getValue = (state: { value: string }) => state.value
+
+  const saga = function*() {
+    yield select(getValue)
+  }
+
+  use(saga)
+    .should.select(getValue)
+    .run()
+})
+
+test('should.actionChannel()', () => {
+  const saga = function*() {
+    yield actionChannel('FETCH')
+  }
+
+  use(saga)
+    .should.actionChannel('FETCH')
+    .run()
+})
+
+test('should.flush()', () => {
+  const chan = channel()
+
+  const saga = function*() {
+    yield flush(chan)
+  }
+
+  use(saga)
+    .should.flush(chan)
+    .run()
+})
+
+test('should.cancelled()', () => {
+  const saga = function*() {
+    yield cancelled()
+  }
+
+  use(saga)
+    .should.cancelled()
+    .run()
+})
+
+test('should.setContext()', () => {
+  const context = { key: 'value' }
+
+  const saga = function*() {
+    yield setContext(context)
+  }
+
+  use(saga)
+    .should.setContext(context)
+    .run()
+})
+
+test('should.getContext()', () => {
+  const saga = function*() {
+    yield getContext('key')
+  }
+
+  use(saga)
+    .should.getContext('key')
+    .run()
+})
+
+test('should.delay()', () => {
+  const saga = function*() {
+    yield delay(1000)
+  }
+
+  use(saga)
+    .should.delay(1000)
+    .run()
+})
+
+test('should.throttle()', () => {
+  const saga = function*() {
+    yield throttle(1000, 'FETCH', fn1)
+  }
+
+  use(saga)
+    .should.throttle(1000, 'FETCH', fn1)
+    .run()
+})
+
+test('should.debounce()', () => {
+  const saga = function*() {
+    yield debounce(1000, 'FETCH', fn1)
+  }
+
+  use(saga)
+    .should.debounce(1000, 'FETCH', fn1)
+    .run()
+})
+
+test('should.retry()', () => {
+  const saga = function*() {
+    yield retry(3, 10, fn1)
+  }
+
+  use(saga)
+    .should.retry(3, 10, fn1)
+    .run()
+})
+
+test('should.all()', () => {
+  const saga = function*() {
+    yield all([call(fn1), call(fn2)])
+  }
+
+  use(saga)
+    .should.all([call(fn1), call(fn2)])
+    .run()
+})
+
+test('should.race()', () => {
+  const saga = function*() {
+    yield race({
+      response1: call(fn1),
+      response2: call(fn2),
+    })
+  }
+
+  use(saga)
+    .should.race({
+      response1: call(fn1),
+      response2: call(fn2),
+    })
+    .run()
+})

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -1,4 +1,4 @@
-import { put, call, take, Effect } from 'redux-saga/effects'
+import { Effect, put, call } from 'redux-saga/effects'
 import { use, throwError, finalize, SagaRunner } from '../src/runner'
 
 const fn1 = () => {}
@@ -577,41 +577,5 @@ describe('should.throw()', () => {
         .run()
 
     expect(runSaga).toThrow('Assertion failure')
-  })
-})
-
-describe('should.put()', () => {
-  const saga = function*() {
-    yield put({ type: 'SUCCESS' })
-  }
-
-  test('asserts that the saga emits PUT effect', () => {
-    use(saga)
-      .should.put({ type: 'SUCCESS' })
-      .run()
-  })
-})
-
-describe('should.call()', () => {
-  const saga = function*() {
-    yield call(fn1)
-  }
-
-  test('asserts that the saga emits CALL effect', () => {
-    use(saga)
-      .should.call(fn1)
-      .run()
-  })
-})
-
-describe('should.take()', () => {
-  const saga = function*() {
-    yield take('FETCH')
-  }
-
-  test('asserts that the saga emits TAKE effect', () => {
-    use(saga)
-      .should.take('FETCH')
-      .run()
   })
 })


### PR DESCRIPTION
Adds assertion aliases to `should` interface for these effect creators:

```js
take(pattern)
takeMaybe(pattern)
take(channel)
takeMaybe(channel)
takeEvery(pattern, saga, ...args)
takeEvery(channel, saga, ...args)
takeLatest(pattern, saga, ..args)
takeLatest(channel, saga, ..args)
takeLeading(pattern, saga, ..args)
takeLeading(channel, saga, ..args)
put(action)
putResolve(action)
put(channel, action)
call(fn, ...args)
call([context, fn], ...args)
call([context, fnName], ...args)
call({context, fn}, ...args)
apply(context, fn, args)
cps(fn, ...args)
cps([context, fn], ...args)
cps({context, fn}, ...args)
fork(fn, ...args)
fork([context, fn], ...args)
fork({context, fn}, ...args)
spawn(fn, ...args)
spawn([context, fn], ...args)
join(task)
join([...tasks])
cancel(task)
cancel([...tasks])
cancel()
select(selector, ...args)
actionChannel(pattern, [buffer])
flush(channel)
cancelled()
setContext(props)
getContext(prop)
delay(ms, [val])
throttle(ms, pattern, saga, ..args)
throttle(ms, channel, saga, ..args)
debounce(ms, pattern, saga, ..args)
debounce(ms, channel, saga, ..args)
retry(maxTries, delay, fn, ...args)
race(effects)
race([...effects])
all([...effects]) (aka parallel effects)
all(effects)
```