### PR TITLE
More relevant stack traces

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,13 +48,13 @@ export function matchError(error: Error, pattern: ErrorPattern) {
   return false
 }
 
-export function createError(message: string, ssf?: Function): Error {
+export function createError(message: string, stack?: Function): Error {
   const error = new Error(message)
 
-  if (ssf) {
+  if (stack) {
     const limit = Error.stackTraceLimit
     Error.stackTraceLimit = 1
-    Error.captureStackTrace(error, ssf)
+    Error.captureStackTrace(error, stack)
     Error.stackTraceLimit = limit
   }
 

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -25,8 +25,8 @@ describe('createRunner()', () => {
     expect(runner).toHaveProperty('run')
 
     // prevents breaking changes
-    const runner2 = use(saga)
-    expect(runner2).toHaveProperty('mock')
+    expect(use).toStrictEqual(createRunner)
+    expect(runner.mock).toStrictEqual(runner.inject)
   })
 
   test('does not create a runner without providing a saga', () => {
@@ -146,16 +146,6 @@ describe('inject()', () => {
       .run()
 
     expect(output.effects).toContainEqual(
-      put({ type: 'SUCCESS', payload: 'result' }),
-    )
-
-    // prevents breaking changes
-
-    const output2 = createRunner(saga)
-      .mock(call(fn1), 'result')
-      .run()
-
-    expect(output2.effects).toContainEqual(
       put({ type: 'SUCCESS', payload: 'result' }),
     )
   })


### PR DESCRIPTION
When the runner throws errors, the printed stack traces are now more relevant.