### PR TITLE
Assertions without run

### DIFF
--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -27,21 +27,19 @@ import {
   race,
 } from 'redux-saga/effects'
 import { Effect } from '@redux-saga/types'
-import { SagaRunner, SagaRunnerState } from './types/runner'
+import { SagaRunner } from './types/runner'
 
 export const getExtendedSagaAssertions = (
   runner: SagaRunner,
-  newState: SagaRunnerState,
   isNegated: () => boolean,
   _yield: (
     runner: SagaRunner,
-    state: SagaRunnerState,
     isNegated: () => boolean,
   ) => (...args: any[]) => SagaRunner,
 ) => {
   const createAlias = (effectCreator: (...args: any[]) => Effect) => (
     ...args: any[]
-  ) => _yield(runner, newState, isNegated)(effectCreator(...args))
+  ) => _yield(runner, isNegated)(effectCreator(...args))
 
   return {
     take: createAlias(take),

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,14 +19,7 @@ export function createRunner<Saga extends (...args: any[]) => any>(
     throw createError('Missing saga argument', createRunner)
   }
 
-  return _createRunner(
-    {
-      injections: [],
-      assertions: [],
-    },
-    saga,
-    args,
-  )
+  return _createRunner({ injections: [] }, saga, args)
 }
 
 /**

--- a/src/types/runner.ts
+++ b/src/types/runner.ts
@@ -89,8 +89,7 @@ export interface Finalize {
 
 export interface SagaRunnerState {
   injections: Injection[]
-  assertions: Array<(output: SagaOutput) => void>
-  errorPattern?: ErrorPattern
+  catchingError?: ErrorPattern
 }
 
 export interface Injection {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { IO } from '@redux-saga/symbols'
 import { THROW_ERROR, FINALIZE, ErrorPattern, SagaOutput } from './types/runner'
 
-export function next(iterator: Iterator<any>, value: any) {
+export function next<T>(iterator: Iterator<T>, value: any): IteratorResult<T> {
   if (value !== null && typeof value === 'object') {
     if (THROW_ERROR in value) return iterator.throw!(value.error)
     if (FINALIZE in value) return iterator.return!()
@@ -10,18 +10,18 @@ export function next(iterator: Iterator<any>, value: any) {
   return iterator.next(value)
 }
 
-export function isEffect(obj: Object) {
+export function isEffect(obj: Object): boolean {
   return obj !== null && typeof obj === 'object' && IO in obj
 }
 
 export function createAssert(
   assert: (output: SagaOutput) => boolean,
   reverse: boolean,
-) {
+): (output: SagaOutput) => boolean {
   return (output: SagaOutput) => (reverse ? !assert(output) : assert(output))
 }
 
-export function matchError(error: Error, pattern: ErrorPattern) {
+export function matchError(error: Error, pattern: ErrorPattern): boolean {
   if (typeof error !== 'object') error = { name: '', message: error }
   if (!error.message) return false
 

--- a/test/aliases.test.ts
+++ b/test/aliases.test.ts
@@ -42,7 +42,6 @@ test('should.take()', () => {
   createRunner(saga)
     .should.take('FETCH_USER')
     .should.not.take('FETCH_PRODUCT')
-    .run()
 })
 
 test('should.takeMaybe()', () => {
@@ -53,7 +52,6 @@ test('should.takeMaybe()', () => {
   createRunner(saga)
     .should.takeMaybe('FETCH_USER')
     .should.not.takeMaybe('FETCH_PRODUCT')
-    .run()
 })
 
 test('should.takeEvery()', () => {
@@ -64,7 +62,6 @@ test('should.takeEvery()', () => {
   createRunner(saga)
     .should.takeEvery('FETCH_USER', fn1)
     .should.not.takeEvery('FETCH_USER', fn2)
-    .run()
 })
 
 test('should.takeLatest()', () => {
@@ -75,7 +72,6 @@ test('should.takeLatest()', () => {
   createRunner(saga)
     .should.takeLatest('FETCH_USER', fn1)
     .should.not.takeLatest('FETCH_USER', fn2)
-    .run()
 })
 
 test('should.takeLeading()', () => {
@@ -86,7 +82,6 @@ test('should.takeLeading()', () => {
   createRunner(saga)
     .should.takeLeading('FETCH_USER', fn1)
     .should.not.takeLeading('FETCH_PRODUCT', fn1)
-    .run()
 })
 
 test('should.put()', () => {
@@ -97,7 +92,6 @@ test('should.put()', () => {
   createRunner(saga)
     .should.put({ type: 'SUCCESS' })
     .should.not.put({ type: 'FAILURE' })
-    .run()
 })
 
 test('should.putResolve()', () => {
@@ -108,7 +102,6 @@ test('should.putResolve()', () => {
   createRunner(saga)
     .should.putResolve({ type: 'SUCCESS' })
     .should.not.putResolve({ type: 'FAILURE' })
-    .run()
 })
 
 test('should.call()', () => {
@@ -119,7 +112,6 @@ test('should.call()', () => {
   createRunner(saga)
     .should.call(fn1)
     .should.not.call(fn2)
-    .run()
 })
 
 test('should.apply()', () => {
@@ -130,7 +122,6 @@ test('should.apply()', () => {
   createRunner(saga)
     .should.apply({ key: 'value' }, fn1, [])
     .should.not.apply({ key: 'value' }, fn2, [])
-    .run()
 })
 
 test('should.cps()', () => {
@@ -141,7 +132,6 @@ test('should.cps()', () => {
   createRunner(saga)
     .should.cps(fn1)
     .should.not.cps(fn2)
-    .run()
 })
 
 test('should.fork()', () => {
@@ -152,7 +142,6 @@ test('should.fork()', () => {
   createRunner(saga)
     .should.fork(fn1)
     .should.not.fork(fn2)
-    .run()
 })
 
 test('should.spawn()', () => {
@@ -163,7 +152,6 @@ test('should.spawn()', () => {
   createRunner(saga)
     .should.spawn(fn1)
     .should.not.spawn(fn2)
-    .run()
 })
 
 test('should.join()', () => {
@@ -178,7 +166,6 @@ test('should.join()', () => {
     .inject(fork(fn1), mockTask)
     .should.join(mockTask)
     .should.not.join(createMockTask())
-    .run()
 })
 
 test('should.cancel()', () => {
@@ -193,7 +180,6 @@ test('should.cancel()', () => {
     .inject(fork(fn1), mockTask)
     .should.cancel(mockTask)
     .should.not.cancel(createMockTask())
-    .run()
 })
 
 test('should.select()', () => {
@@ -207,7 +193,6 @@ test('should.select()', () => {
   createRunner(saga)
     .should.select(getUser)
     .should.not.select(getProduct)
-    .run()
 })
 
 test('should.actionChannel()', () => {
@@ -218,7 +203,6 @@ test('should.actionChannel()', () => {
   createRunner(saga)
     .should.actionChannel('FETCH_USER')
     .should.not.actionChannel('FETCH_PRODUCT')
-    .run()
 })
 
 test('should.flush()', () => {
@@ -231,7 +215,6 @@ test('should.flush()', () => {
   createRunner(saga)
     .should.flush(chan)
     .should.not.flush(channel())
-    .run()
 })
 
 test('should.cancelled()', () => {
@@ -241,13 +224,9 @@ test('should.cancelled()', () => {
     }
   }
 
-  createRunner(saga, true)
-    .should.cancelled()
-    .run()
+  createRunner(saga, true).should.cancelled()
 
-  createRunner(saga, false)
-    .should.not.cancelled()
-    .run()
+  createRunner(saga, false).should.not.cancelled()
 })
 
 test('should.setContext()', () => {
@@ -258,7 +237,6 @@ test('should.setContext()', () => {
   createRunner(saga)
     .should.setContext({ key: 'user' })
     .should.not.setContext({ key: 'product' })
-    .run()
 })
 
 test('should.getContext()', () => {
@@ -269,7 +247,6 @@ test('should.getContext()', () => {
   createRunner(saga)
     .should.getContext('key')
     .should.not.getContext('name')
-    .run()
 })
 
 test('should.delay()', () => {
@@ -280,7 +257,6 @@ test('should.delay()', () => {
   createRunner(saga)
     .should.delay(1000)
     .should.not.delay(3000)
-    .run()
 })
 
 test('should.throttle()', () => {
@@ -293,7 +269,6 @@ test('should.throttle()', () => {
     .should.not.throttle(3000, 'FETCH_USER', fn1)
     .should.not.throttle(1000, 'FETCH_PRODUCT', fn1)
     .should.not.throttle(1000, 'FETCH_USER', fn2)
-    .run()
 })
 
 test('should.debounce()', () => {
@@ -306,7 +281,6 @@ test('should.debounce()', () => {
     .should.not.debounce(3000, 'FETCH_USER', fn1)
     .should.not.debounce(1000, 'FETCH_PRODUCT', fn1)
     .should.not.debounce(1000, 'FETCH_USER', fn2)
-    .run()
 })
 
 test('should.retry()', () => {
@@ -319,7 +293,6 @@ test('should.retry()', () => {
     .should.not.retry(5, 10, fn1)
     .should.not.retry(3, 30, fn1)
     .should.not.retry(5, 10, fn2)
-    .run()
 })
 
 test('should.all()', () => {
@@ -332,7 +305,6 @@ test('should.all()', () => {
     .should.not.all([call(fn1)])
     .should.not.all([call(fn1), call(fn2), call(fn3)])
     .should.not.all([call(fn2), call(fn1)])
-    .run()
 })
 
 test('should.race()', () => {
@@ -360,5 +332,4 @@ test('should.race()', () => {
       response1: call(fn2),
       response2: call(fn1),
     })
-    .run()
 })

--- a/test/examples.test.ts
+++ b/test/examples.test.ts
@@ -23,7 +23,6 @@ test('fetchUser() should dispatch FETCH_SUCCESS', () => {
   createRunner(fetchUser, id)
     .inject(call(service.getUser, id), mockUser)
     .should.put({ type: 'FETCH_SUCCESS', payload: mockUser })
-    .run()
 })
 
 test('fetchUser() should dispatch FETCH_FAILURE', () => {
@@ -33,7 +32,6 @@ test('fetchUser() should dispatch FETCH_FAILURE', () => {
   createRunner(fetchUser, id)
     .inject(call(service.getUser, id), throwError(mockError))
     .should.put({ type: 'FETCH_FAILURE', payload: mockError.message })
-    .run()
 })
 
 function* watchNotify() {
@@ -51,7 +49,6 @@ test('watchNotify() should dispatch NOTIFY_END', () => {
   createRunner(watchNotify)
     .inject(call(service.notify), finalize())
     .should.put({ type: 'NOTIFY_END' })
-    .run()
 })
 
 function* findUser(id: number) {
@@ -69,6 +66,6 @@ test('findUser() should throw an error', () => {
 
   createRunner(findUser, id)
     .inject(call(service.getUser, id), undefined)
+    .catch(Error)
     .should.throw(/^Unable to find user/)
-    .run()
 })

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -418,19 +418,6 @@ describe('catch()', () => {
     expect(runSaga).toThrow(sagaError.message)
   })
 
-  test('does not catch an error that is not thrown by the saga', () => {
-    const saga = function*() {
-      yield put({ type: 'SUCCESS' })
-    }
-
-    const runSaga = () =>
-      createRunner(saga)
-        .catch(Error)
-        .run()
-
-    expect(runSaga).toThrow('No error thrown by the saga')
-  })
-
   test('does not catch a thrown object that does not have "message" property', () => {
     const saga = function*() {
       yield call(fn1)
@@ -473,6 +460,19 @@ describe('catch()', () => {
 
     expect(runSaga).toThrow('Missing error pattern argument')
   })
+
+  test('does not catch an error that is not thrown', () => {
+    const saga = function*() {
+      yield call(fn1)
+    }
+
+    const runSaga = () =>
+      createRunner(saga)
+        .catch(Error)
+        .run()
+
+    expect(runSaga).toThrow('No error thrown by the saga')
+  })
 })
 
 describe('should.yield()', () => {
@@ -481,22 +481,15 @@ describe('should.yield()', () => {
   }
 
   test('asserts that the saga yields an effect', () => {
-    createRunner(saga)
-      .should.yield(put({ type: 'SUCCESS', payload: 'result' }))
-      .run()
+    createRunner(saga).should.yield(put({ type: 'SUCCESS', payload: 'result' }))
   })
 
   test('asserts that the saga does not yield an effect', () => {
-    createRunner(saga)
-      .should.not.yield(call(fn1))
-      .run()
+    createRunner(saga).should.not.yield(call(fn1))
   })
 
   test('does not assert that the saga yields an effect', () => {
-    const runSaga = () =>
-      createRunner(saga)
-        .should.yield(call(fn1))
-        .run()
+    const runSaga = () => createRunner(saga).should.yield(call(fn1))
 
     expect(runSaga).toThrow('Assertion failure')
   })
@@ -508,22 +501,15 @@ describe('should.return()', () => {
   }
 
   test('asserts that the saga returns a value', () => {
-    createRunner(saga)
-      .should.return('result1')
-      .run()
+    createRunner(saga).should.return('result1')
   })
 
   test('asserts that the saga does not return a value', () => {
-    createRunner(saga)
-      .should.not.return('result2')
-      .run()
+    createRunner(saga).should.not.return('result2')
   })
 
   test('does not assert that the saga returns a value', () => {
-    const runSaga = () =>
-      createRunner(saga)
-        .should.return('result2')
-        .run()
+    const runSaga = () => createRunner(saga).should.return('result2')
 
     expect(runSaga).toThrow('Assertion failure')
   })
@@ -535,24 +521,33 @@ describe('should.throw()', () => {
     throw sagaError
   }
 
-  test('asserts that the saga throwns an error', () => {
+  test('asserts that the saga throws an error', () => {
     createRunner(saga)
+      .catch(Error)
       .should.throw(sagaError.message)
-      .run()
   })
 
   test('asserts that the saga does not throw an error', () => {
     createRunner(saga)
-      .should.not.throw('unthrown')
       .catch(sagaError.message)
-      .run()
+      .should.not.throw('unthrown')
   })
 
-  test('does not assert that the saga throwns an error', () => {
+  test('does not assert that the saga throws an error', () => {
     const runSaga = () =>
       createRunner(saga)
+        .catch(sagaError.message)
         .should.throw('unthrown')
-        .run()
+
+    expect(runSaga).toThrow('Assertion failure')
+  })
+
+  test('does not assert that the saga throws an error that is not thrown', () => {
+    const saga = function*() {
+      yield put({ type: 'SUCCESS' })
+    }
+
+    const runSaga = () => createRunner(saga).should.throw(Error)
 
     expect(runSaga).toThrow('Assertion failure')
   })


### PR DESCRIPTION
Allows to make tests with assertions without explicitly call `.run()` at the end of the chain: 

Before: 

```ts
  createRunner(fetchUser)
    .should.put({ type: 'FETCH_SUCCESS' })
    .run() 

    // run() was mandatory
```

Now: 

```ts
  createRunner(fetchUser)
    .should.put({ type: 'FETCH_SUCCESS' })

    // it is not required to call run() after assertions
```