### PR TITLE
Cached saga output

### DIFF
--- a/src/types/runner.ts
+++ b/src/types/runner.ts
@@ -90,6 +90,7 @@ export interface Finalize {
 export interface SagaRunnerState {
   injections: Injection[]
   catchingError?: ErrorPattern
+  output?: SagaOutput
 }
 
 export interface Injection {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,11 @@
 import { IO } from '@redux-saga/symbols'
-import { THROW_ERROR, FINALIZE, ErrorPattern, SagaOutput } from './types/runner'
+import {
+  THROW_ERROR,
+  FINALIZE,
+  ErrorPattern,
+  SagaOutput,
+  SagaRunnerState,
+} from './types/runner'
 
 export function next<T>(iterator: Iterator<T>, value: any): IteratorResult<T> {
   if (value !== null && typeof value === 'object') {
@@ -59,4 +65,10 @@ export function createError(message: string, stack?: Function): Error {
   }
 
   return error
+}
+
+export function resetOutputCache(state: SagaRunnerState): void {
+  if (state.output !== undefined) {
+    delete state.output
+  }
 }


### PR DESCRIPTION
Internal feature that prevents running too much times a saga when it was previously executed with an assertion or `run()`.