### PR TITLE
Make runner.should.return(...) callable with argument 0 or undefined

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -141,13 +141,6 @@ export const _return = (
   isNegated: () => boolean,
   stackFunction?: Function,
 ) => (value: any): SagaRunner => {
-  if (!value) {
-    throw createError(
-      'Missing return value argument',
-      stackFunction || runner.should.return,
-    )
-  }
-
   const output = _run(runner, state, stackFunction)()
 
   const assert = createAssert(

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -538,17 +538,20 @@ describe('should.return()', () => {
     expect(runSaga).toThrow('Assertion failure')
   })
 
-  test('does not assert that the saga returns a value without providing a return value argument', () => {
+  test('does accept "0" as an argument', () => {
     const saga = function*() {
-      return 'result'
+      return 0
     }
 
-    const runSaga = () =>
-      (createRunner(saga) as SagaRunner & {
-        should: { return: () => SagaRunner }
-      }).should.return()
+    createRunner(saga).should.return(0)
+  })
 
-    expect(runSaga).toThrow('Missing return value argument')
+  test('does accept "undefined" as an argument', () => {
+    const saga = function*() {
+      return
+    }
+
+    createRunner(saga).should.return(undefined)
   })
 })
 


### PR DESCRIPTION
These following cases should not throw errors "missing argument" when `runner.should.return(...)` is invoked with `0` : 

```js
function *saga() {
  yield put({ type: 'HELLO' });
  return 0;
}

const runner = createRunner(saga);
runner.should.return(0);
```

or `undefined`: 

```js
function *saga(value) {
  if (value === undefined) {
    throw new Error('empty value');
  }

  yield put({ type: 'SUCCESS' });
}

const runner = createRunner(saga, "given value");
runner.should.return(undefined);
```