### PR TITLE
Finalize with argument

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,6 +1,5 @@
 {
   "*.+(ts|js|json|yml|md)": [
-    "prettier --write",
-    "git add"
+    "prettier --write"
   ]
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@
   - [`runner.run()`][runner.run]
   - [`runner.should`][runner.should]
 - [`throwError(error)`][throwerror]
-- [`finalize()`][finalize]
+- [`finalize(value?)`][finalize]
 - [`RunnerOutput`][runneroutput]
 - [`Assertions`][assertions]
   - [`runner.should.yield(effect)`][runner.should.yield]
@@ -169,9 +169,11 @@ createRunner(fetchUser, fetchUserAction)
   .run();
 ```
 
-## finalize()
+## finalize(value?)
 
 Finalizes the saga when mapped as a value with [`runner.map()`][runner.map].
+
+Can be used to break an infinite loop.
 
 Returns a `Finalize` value.
 
@@ -180,6 +182,14 @@ Example:
 ```js
 createRunner(fetchUser, fetchUserAction)
   .map(getUser, finalize())
+  .run();
+```
+
+or by passing a mapped value to the effect:
+
+```js
+createRunner(fetchUser, fetchUserAction)
+  .map(getUser, finalize(user))
   .run();
 ```
 
@@ -312,7 +322,7 @@ createRunner(fetchUser, fetchUserAction)
 [runner.run]: #runnerrun
 [runner.should]: #runnershould
 [throwerror]: #throwerrorerror
-[finalize]: #finalize
+[finalize]: #finalizevalue
 [runneroutput]: #runneroutput
 [assertions]: #assertions
 [runner.should.yield]: #runnershouldyieldeffect

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -425,7 +425,7 @@ You can [see more details here][runner.clone].
 [runner.run]: api.md#runnerrun
 [runner.should]: api.md#runnershould
 [throwerror]: api.md#throwerrorerror
-[finalize]: api.md#finalize
+[finalize]: api.md#finalizevalue
 [runneroutput]: api.md#runneroutput
 [runner.should.yield]: api.md#runnershouldyieldeffect
 [runner.should.return]: api.md#runnershouldreturnvalue

--- a/package-lock.json
+++ b/package-lock.json
@@ -5104,9 +5104,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
-      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "jest": "^25.2.4",
     "lint-staged": "^10.1.1",
     "madge": "^3.8.0",
-    "prettier": "^2.0.2",
+    "prettier": "^1",
     "redux-saga": "^1.1.3",
     "ts-jest": "^25.3.0",
     "typescript": "^3.8.3"

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -35,8 +35,9 @@ export interface ThrowError {
 
 const FINALIZE = 'FINALIZE';
 
-export interface Finalize {
+export interface Finalize<T> {
   [ENGINE]: typeof FINALIZE;
+  value?: T;
 }
 
 const MAX_YIELDED_EFFECTS = 100;
@@ -223,6 +224,9 @@ export class Engine {
         case THROW_ERROR:
           return iterator.throw!(value.error);
         case FINALIZE:
+          if (value.value !== undefined) {
+            iterator.next(value.value);
+          }
           return iterator.return!();
       }
     }
@@ -248,6 +252,9 @@ export function throwError(error: Error): ThrowError {
 /**
  * Finalizes the saga when mapped as a value.
  */
-export function finalize(): Finalize {
-  return { [ENGINE]: FINALIZE };
+export function finalize<T>(value?: T): Finalize<T> {
+  return {
+    [ENGINE]: FINALIZE,
+    value,
+  };
 }

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -174,11 +174,12 @@ describe('runner.map()', () => {
 
   test('maps an effect to finalize()', () => {
     const saga = function*() {
+      let result = undefined;
       try {
-        yield call(fn1);
+        result = yield call(fn1);
         yield put({ type: 'SUCCESS' });
       } finally {
-        yield put({ type: 'END' });
+        yield put({ type: 'END', result });
       }
     };
 
@@ -187,6 +188,27 @@ describe('runner.map()', () => {
       .run();
 
     expect(output.effects).toEqual([call(fn1), put({ type: 'END' })]);
+  });
+
+  test('maps an effect to finalize() with a value', () => {
+    const saga = function*() {
+      let result = undefined;
+      try {
+        result = yield call(fn1);
+        yield put({ type: 'SUCCESS' });
+      } finally {
+        yield put({ type: 'END', result });
+      }
+    };
+
+    const output = createRunner(saga)
+      .map(call(fn1), finalize('result'))
+      .run();
+
+    expect(output.effects).toEqual([
+      call(fn1),
+      put({ type: 'END', result: 'result' }),
+    ]);
   });
 
   test('maps an effect to several values', () => {


### PR DESCRIPTION
It adds the ability to pass an argument to `finalize()` helper, allowing to map the given effect with a value and then finalize the saga.